### PR TITLE
remove qrcode from imports in utils.py

### DIFF
--- a/custom_components/smartthings_find/utils.py
+++ b/custom_components/smartthings_find/utils.py
@@ -1,7 +1,6 @@
 import logging
 import json
 import pytz
-import qrcode
 import base64
 import aiohttp
 import asyncio


### PR DESCRIPTION
Fixed error: ERROR (MainThread) [homeassistant.config_entries] Error occurred loading flow for integration smartthings_find ││ : No module named 'qrcode' 
for me which happend while trying to set up the integration. 

Deleting the single line fixed my issue and allowed me to set up integration sucessfully